### PR TITLE
Faster hash library xxh3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+*.prof
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+*.html
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/BENCH.md
+++ b/BENCH.md
@@ -24,20 +24,20 @@ MAPBENCH=100000 go test
 ## STRING KEYS
 
 -- tidwall --
-set          100,000 ops     15ms      6,755,229/sec 
-get          100,000 ops      9ms     11,480,505/sec 
-reset        100,000 ops      6ms     15,393,057/sec 
-scan              20 ops     12ms          1,643/sec 
-delete       100,000 ops      8ms     12,024,028/sec 
+set          100,000 ops     15ms      6,535,956/sec 
+get          100,000 ops      7ms     15,009,648/sec 
+reset        100,000 ops      5ms     20,811,745/sec 
+scan              20 ops      8ms          2,539/sec 
+delete       100,000 ops      7ms     14,557,933/sec 
 memory     4,194,288 bytes                  41/entry 
 
 -- stdlib --
-set          100,000 ops     22ms      4,618,215/sec 
-get          100,000 ops      9ms     10,560,800/sec 
-reset        100,000 ops      6ms     15,763,082/sec 
-scan              20 ops     16ms          1,275/sec 
-delete       100,000 ops      9ms     11,645,027/sec 
-memory     3,960,672 bytes                  39/entry 
+set          100,000 ops     17ms      5,892,223/sec 
+get          100,000 ops      8ms     12,148,359/sec 
+reset        100,000 ops      4ms     24,779,419/sec 
+scan              20 ops     14ms          1,395/sec 
+delete       100,000 ops      8ms     11,915,708/sec 
+memory     3,966,288 bytes                  39/entry
 ```
 
 ## 100,000 random int keys
@@ -46,20 +46,20 @@ memory     3,960,672 bytes                  39/entry
 ## INT KEYS
 
 -- tidwall --
-set          100,000 ops     13ms      7,655,039/sec 
-get          100,000 ops      8ms     12,273,792/sec 
-reset        100,000 ops      8ms     12,403,374/sec 
-scan              20 ops     18ms          1,090/sec 
-delete       100,000 ops     10ms     10,240,310/sec 
-memory     3,143,448 bytes                  31/entry 
+set          100,000 ops      8ms     12,573,069/sec 
+get          100,000 ops      4ms     24,821,181/sec 
+reset        100,000 ops      4ms     25,324,412/sec 
+scan              20 ops      8ms          2,430/sec 
+delete       100,000 ops      5ms     22,156,034/sec 
+memory     3,143,352 bytes                  31/entry 
 
 -- stdlib --
-set          100,000 ops     10ms     10,356,513/sec 
-get          100,000 ops      5ms     20,322,233/sec 
-reset        100,000 ops      5ms     21,655,755/sec 
-scan              20 ops     20ms          1,001/sec 
-delete       100,000 ops      4ms     22,516,827/sec 
-memory     2,767,704 bytes                  27/entry 
+set          100,000 ops      7ms     13,547,121/sec 
+get          100,000 ops      4ms     26,458,302/sec 
+reset        100,000 ops      4ms     28,379,163/sec 
+scan              20 ops     16ms          1,214/sec 
+delete       100,000 ops      4ms     24,771,495/sec 
+memory     2,784,264 bytes                  27/entry 
 ```
 
 ## 1,000,000 random string keys
@@ -68,19 +68,19 @@ memory     2,767,704 bytes                  27/entry
 ## STRING KEYS
 
 -- tidwall --
-set        1,000,000 ops    236ms      4,234,342/sec 
-get        1,000,000 ops    132ms      7,563,164/sec 
-reset      1,000,000 ops    125ms      8,025,718/sec 
-scan              20 ops    135ms            148/sec 
-delete     1,000,000 ops    141ms      7,091,525/sec 
+set        1,000,000 ops    217ms      4,607,387/sec 
+get        1,000,000 ops    127ms      7,872,817/sec 
+reset      1,000,000 ops    130ms      7,709,027/sec 
+scan              20 ops    136ms            147/sec 
+delete     1,000,000 ops    149ms      6,716,045/sec 
 memory    67,108,848 bytes                  67/entry 
 
 -- stdlib --
-set        1,000,000 ops    351ms      2,851,085/sec 
-get        1,000,000 ops    119ms      8,381,478/sec 
-reset      1,000,000 ops    123ms      8,114,941/sec 
-scan              20 ops    154ms            130/sec 
-delete     1,000,000 ops    137ms      7,322,445/sec 
+set        1,000,000 ops    325ms      3,078,132/sec 
+get        1,000,000 ops    122ms      8,217,771/sec 
+reset      1,000,000 ops    133ms      7,510,273/sec 
+scan              20 ops    163ms            122/sec 
+delete     1,000,000 ops    148ms      6,761,332/sec 
 memory    57,931,472 bytes                  57/entry
 ```
 
@@ -90,20 +90,20 @@ memory    57,931,472 bytes                  57/entry
 ## INT KEYS
 
 -- tidwall --
-set        1,000,000 ops    105ms      9,490,462/sec 
-get        1,000,000 ops     67ms     14,865,120/sec 
-reset      1,000,000 ops     61ms     16,336,651/sec 
-scan              20 ops    138ms            144/sec 
-delete     1,000,000 ops     66ms     15,078,569/sec 
+set        1,000,000 ops    101ms      9,901,395/sec 
+get        1,000,000 ops     63ms     15,928,770/sec 
+reset      1,000,000 ops     66ms     15,107,262/sec 
+scan              20 ops    139ms            144/sec 
+delete     1,000,000 ops     66ms     15,216,322/sec 
 memory    50,329,272 bytes                  50/entry 
 
 -- stdlib --
-set        1,000,000 ops    155ms      6,469,942/sec 
-get        1,000,000 ops     69ms     14,390,932/sec 
-reset      1,000,000 ops     53ms     18,828,756/sec 
+set        1,000,000 ops    119ms      8,431,961/sec 
+get        1,000,000 ops     61ms     16,376,595/sec 
+reset      1,000,000 ops     59ms     17,032,395/sec 
 scan              20 ops    153ms            130/sec 
-delete     1,000,000 ops     58ms     17,238,929/sec 
-memory    40,146,664 bytes                  40/entry 
+delete     1,000,000 ops     67ms     15,026,654/sec 
+memory    40,146,760 bytes                  40/entry 
 ```
 
 ## 10,000,000 random string keys (int values)
@@ -112,19 +112,19 @@ memory    40,146,664 bytes                  40/entry
 ## STRING KEYS
 
 -- tidwall --
-set       10,000,000 ops   2438ms      4,102,284/sec 
-get       10,000,000 ops   1383ms      7,232,811/sec 
-reset     10,000,000 ops   1443ms      6,928,121/sec 
+set       10,000,000 ops   2584ms      3,869,389/sec 
+get       10,000,000 ops   1418ms      7,051,328/sec 
+reset     10,000,000 ops   1469ms      6,807,487/sec 
 scan              20 ops   1049ms             19/sec 
-delete    10,000,000 ops   1691ms      5,915,335/sec 
+delete    10,000,000 ops   1694ms      5,901,787/sec 
 memory   536,870,896 bytes                  53/entry 
 
 -- stdlib --
-set       10,000,000 ops   3572ms      2,799,176/sec 
-get       10,000,000 ops   1447ms      6,911,076/sec 
-reset     10,000,000 ops   1436ms      6,965,708/sec 
-scan              20 ops   1772ms             11/sec 
-delete    10,000,000 ops   1560ms      6,412,190/sec 
+set       10,000,000 ops   3771ms      2,651,828/sec 
+get       10,000,000 ops   1494ms      6,695,021/sec 
+reset     10,000,000 ops   1480ms      6,758,881/sec 
+scan              20 ops   1855ms             10/sec 
+delete    10,000,000 ops   1629ms      6,138,209/sec 
 memory   463,468,240 bytes                  46/entry
 ```
 
@@ -134,18 +134,18 @@ memory   463,468,240 bytes                  46/entry
 ## INT KEYS
 
 -- tidwall --
-set       10,000,000 ops   1383ms      7,229,909/sec 
-get       10,000,000 ops    754ms     13,260,571/sec 
-reset     10,000,000 ops    778ms     12,860,468/sec 
-scan              20 ops   1083ms             18/sec 
-delete    10,000,000 ops    910ms     10,988,243/sec 
+set       10,000,000 ops   1428ms      7,002,173/sec 
+get       10,000,000 ops    733ms     13,636,196/sec 
+reset     10,000,000 ops    787ms     12,710,144/sec 
+scan              20 ops   1098ms             18/sec 
+delete    10,000,000 ops    900ms     11,108,541/sec 
 memory   402,650,808 bytes                  40/entry 
 
 -- stdlib --
-set       10,000,000 ops   1635ms      6,116,286/sec 
-get       10,000,000 ops    760ms     13,154,962/sec 
-reset     10,000,000 ops    852ms     11,740,869/sec 
-scan              20 ops   1592ms             12/sec 
-delete    10,000,000 ops    889ms     11,253,382/sec 
-memory   321,976,040 bytes                  32/entry 
+set       10,000,000 ops   1709ms      5,850,969/sec 
+get       10,000,000 ops    797ms     12,551,221/sec 
+reset     10,000,000 ops    874ms     11,437,820/sec 
+scan              20 ops   1629ms             12/sec 
+delete    10,000,000 ops    910ms     10,994,436/sec 
+memory   321,976,032 bytes                  32/entry 
 ```

--- a/BENCH.md
+++ b/BENCH.md
@@ -1,11 +1,11 @@
-## Performance
+# Performance
 
-While this implementation was designed with performance in mind, it's not 
-necessarily better, faster, smarter, or sexier than the built-in Go hashmap. 
+While this implementation was designed with performance in mind, it's not
+necessarily better, faster, smarter, or sexier than the built-in Go hashmap.
 
 Here's a very rough comparison.
 
-The following benchmarks were run on my 2019 Macbook Pro (2.4 GHz 8-Core Intel Core i9) using Go version 1.18. The key types are either strings or ints and the values are always ints.
+The following benchmarks were run on a Linux Desktop (3.8 GHz 8-Core AMD Ryzen 7 5800X) using Go version 1.19. The key types are either strings or ints and the values are always ints.
 
 In all cases the maps start from zero capacity, like:
 
@@ -14,139 +14,138 @@ m := make(map[string]int)      // go stdlib
 var m hashmap.Map[string, int] // this package
 ```
 
-```
+```shell
 MAPBENCH=100000 go test
 ```
 
-### 100,000 random string keys
+## 100,000 random string keys
 
-```
+```shell
 ## STRING KEYS
 
 -- tidwall --
-set          100,000 ops     19ms      5,405,235/sec
-get          100,000 ops     12ms      8,599,131/sec
-reset        100,000 ops     12ms      8,463,694/sec
-scan              20 ops     14ms          1,428/sec
-delete       100,000 ops     11ms      8,749,727/sec
-memory     4,194,288 bytes                  41/entry
+set          100,000 ops     15ms      6,755,229/sec 
+get          100,000 ops      9ms     11,480,505/sec 
+reset        100,000 ops      6ms     15,393,057/sec 
+scan              20 ops     12ms          1,643/sec 
+delete       100,000 ops      8ms     12,024,028/sec 
+memory     4,194,288 bytes                  41/entry 
 
 -- stdlib --
-set          100,000 ops     28ms      3,602,606/sec
-get          100,000 ops     17ms      5,842,126/sec
-reset        100,000 ops     13ms      7,489,159/sec
-scan              20 ops     32ms            627/sec
-delete       100,000 ops     13ms      7,545,664/sec
-memory     3,968,784 bytes                  39/entry
+set          100,000 ops     22ms      4,618,215/sec 
+get          100,000 ops      9ms     10,560,800/sec 
+reset        100,000 ops      6ms     15,763,082/sec 
+scan              20 ops     16ms          1,275/sec 
+delete       100,000 ops      9ms     11,645,027/sec 
+memory     3,960,672 bytes                  39/entry 
 ```
 
-### 100,000 random int keys
+## 100,000 random int keys
 
-```
+```shell
 ## INT KEYS
 
 -- tidwall --
-set          100,000 ops     10ms      9,624,083/sec
-get          100,000 ops      5ms     21,056,856/sec
-reset        100,000 ops      5ms     21,281,182/sec
-scan              20 ops     10ms          1,917/sec
-delete       100,000 ops      5ms     18,342,582/sec
-memory     3,143,352 bytes                  31/entry
+set          100,000 ops     13ms      7,655,039/sec 
+get          100,000 ops      8ms     12,273,792/sec 
+reset        100,000 ops      8ms     12,403,374/sec 
+scan              20 ops     18ms          1,090/sec 
+delete       100,000 ops     10ms     10,240,310/sec 
+memory     3,143,448 bytes                  31/entry 
 
 -- stdlib --
-set          100,000 ops     10ms     10,354,476/sec
-get          100,000 ops      4ms     25,693,552/sec
-reset        100,000 ops      4ms     24,752,983/sec
-scan              20 ops     21ms            967/sec
-delete       100,000 ops      5ms     19,239,275/sec
-memory     2,772,744 bytes                  27/entry
+set          100,000 ops     10ms     10,356,513/sec 
+get          100,000 ops      5ms     20,322,233/sec 
+reset        100,000 ops      5ms     21,655,755/sec 
+scan              20 ops     20ms          1,001/sec 
+delete       100,000 ops      4ms     22,516,827/sec 
+memory     2,767,704 bytes                  27/entry 
 ```
 
-### 1,000,000 random string keys
+## 1,000,000 random string keys
 
-```
+```shell
 ## STRING KEYS
 
 -- tidwall --
-set        1,000,000 ops    299ms      3,342,247/sec
-get        1,000,000 ops    141ms      7,099,822/sec
-reset      1,000,000 ops    155ms      6,444,007/sec
-scan              20 ops    244ms             82/sec
-delete     1,000,000 ops    178ms      5,622,242/sec
-memory    67,108,848 bytes                  67/entry
+set        1,000,000 ops    236ms      4,234,342/sec 
+get        1,000,000 ops    132ms      7,563,164/sec 
+reset      1,000,000 ops    125ms      8,025,718/sec 
+scan              20 ops    135ms            148/sec 
+delete     1,000,000 ops    141ms      7,091,525/sec 
+memory    67,108,848 bytes                  67/entry 
 
 -- stdlib --
-set        1,000,000 ops    426ms      2,348,509/sec
-get        1,000,000 ops    142ms      7,019,978/sec
-reset      1,000,000 ops    182ms      5,496,549/sec
-scan              20 ops    297ms             67/sec
-delete     1,000,000 ops    187ms      5,337,449/sec
+set        1,000,000 ops    351ms      2,851,085/sec 
+get        1,000,000 ops    119ms      8,381,478/sec 
+reset      1,000,000 ops    123ms      8,114,941/sec 
+scan              20 ops    154ms            130/sec 
+delete     1,000,000 ops    137ms      7,322,445/sec 
 memory    57,931,472 bytes                  57/entry
 ```
 
-### 1,000,000 random int keys
+## 1,000,000 random int keys
 
-```
+```shell
 ## INT KEYS
 
 -- tidwall --
-set        1,000,000 ops    146ms      6,838,679/sec
-get        1,000,000 ops     72ms     13,798,363/sec
-reset      1,000,000 ops     76ms     13,236,277/sec
-scan              20 ops    243ms             82/sec
-delete     1,000,000 ops    112ms      8,893,494/sec
-memory    50,329,280 bytes                  50/entry
+set        1,000,000 ops    105ms      9,490,462/sec 
+get        1,000,000 ops     67ms     14,865,120/sec 
+reset      1,000,000 ops     61ms     16,336,651/sec 
+scan              20 ops    138ms            144/sec 
+delete     1,000,000 ops     66ms     15,078,569/sec 
+memory    50,329,272 bytes                  50/entry 
 
 -- stdlib --
-set        1,000,000 ops    171ms      5,850,975/sec
-get        1,000,000 ops     71ms     14,096,964/sec
-reset      1,000,000 ops     75ms     13,279,320/sec
-scan              20 ops    285ms             70/sec
-delete     1,000,000 ops     90ms     11,131,406/sec
-memory    40,146,760 bytes                  40/entry
+set        1,000,000 ops    155ms      6,469,942/sec 
+get        1,000,000 ops     69ms     14,390,932/sec 
+reset      1,000,000 ops     53ms     18,828,756/sec 
+scan              20 ops    153ms            130/sec 
+delete     1,000,000 ops     58ms     17,238,929/sec 
+memory    40,146,664 bytes                  40/entry 
 ```
 
-### 10,000,000 random string keys (int values)
+## 10,000,000 random string keys (int values)
 
-```
+```shell
 ## STRING KEYS
 
 -- tidwall --
-set       10,000,000 ops   3185ms      3,139,265/sec
-get       10,000,000 ops   1624ms      6,158,609/sec
-reset     10,000,000 ops   1816ms      5,505,645/sec
-scan              20 ops   2037ms              9/sec
-delete    10,000,000 ops   2137ms      4,678,937/sec
-memory   536,870,904 bytes                  53/entry
+set       10,000,000 ops   2438ms      4,102,284/sec 
+get       10,000,000 ops   1383ms      7,232,811/sec 
+reset     10,000,000 ops   1443ms      6,928,121/sec 
+scan              20 ops   1049ms             19/sec 
+delete    10,000,000 ops   1691ms      5,915,335/sec 
+memory   536,870,896 bytes                  53/entry 
 
 -- stdlib --
-set       10,000,000 ops   4623ms      2,163,071/sec
-get       10,000,000 ops   1764ms      5,670,292/sec
-reset     10,000,000 ops   2389ms      4,185,314/sec
-scan              20 ops   2975ms              6/sec
-delete    10,000,000 ops   2280ms      4,385,089/sec
-memory   463,468,352 bytes                  46/entry
-
+set       10,000,000 ops   3572ms      2,799,176/sec 
+get       10,000,000 ops   1447ms      6,911,076/sec 
+reset     10,000,000 ops   1436ms      6,965,708/sec 
+scan              20 ops   1772ms             11/sec 
+delete    10,000,000 ops   1560ms      6,412,190/sec 
+memory   463,468,240 bytes                  46/entry
 ```
 
-### 10,000,000 random int keys (int values)
+## 10,000,000 random int keys (int values)
 
-```
+```shell
 ## INT KEYS
 
 -- tidwall --
-set       10,000,000 ops   1743ms      5,736,861/sec
-get       10,000,000 ops    878ms     11,394,400/sec
-reset     10,000,000 ops   1003ms      9,965,713/sec
-scan              20 ops   1973ms             10/sec
-delete    10,000,000 ops   1126ms      8,883,210/sec
-memory   402,650,808 bytes                  40/entry
+set       10,000,000 ops   1383ms      7,229,909/sec 
+get       10,000,000 ops    754ms     13,260,571/sec 
+reset     10,000,000 ops    778ms     12,860,468/sec 
+scan              20 ops   1083ms             18/sec 
+delete    10,000,000 ops    910ms     10,988,243/sec 
+memory   402,650,808 bytes                  40/entry 
 
 -- stdlib --
-set       10,000,000 ops   1989ms      5,027,700/sec
-get       10,000,000 ops   1021ms      9,796,267/sec
-reset     10,000,000 ops   1033ms      9,685,070/sec
-scan              20 ops   2847ms              7/sec
-delete    10,000,000 ops   1182ms      8,456,779/sec
-memory   321,976,040 bytes                  32/entry
+set       10,000,000 ops   1635ms      6,116,286/sec 
+get       10,000,000 ops    760ms     13,154,962/sec 
+reset     10,000,000 ops    852ms     11,740,869/sec 
+scan              20 ops   1592ms             12/sec 
+delete    10,000,000 ops    889ms     11,253,382/sec 
+memory   321,976,040 bytes                  32/entry 
 ```

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ This is a rewrite of the [tidwall/rhh](https://github.com/tidwall/rhh) package t
 
 For ordered key-value data, check out the [tidwall/btree](https://github.com/tidwall/btree) package.
 
-# Getting Started
+## Getting Started
 
-## Installing
+### Installing
 
 To start using `hashmap`, install Go and run `go get`:
 
 ```sh
-$ go get github.com/tidwall/hashmap
+go get github.com/tidwall/hashmap
 ```
 
 This will retrieve the library.
@@ -78,4 +78,4 @@ Josh Baker [@tidwall](http://twitter.com/tidwall)
 
 ## License
 
-Source code is available under the MIT [License](/LICENSE).
+Source code is available under the MIT [License](LICENSE).

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/tidwall/hashmap
 
 go 1.18
 
-require github.com/cespare/xxhash/v2 v2.1.2
+require github.com/zeebo/xxh3 v1.0.2
+
+require (
+	github.com/klauspost/cpuid/v2 v2.1.1 // indirect
+	golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
-github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
-github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/klauspost/cpuid/v2 v2.1.1 h1:t0wUqjowdm8ezddV5k0tLWVklVuvLJpoHeb4WBdydm0=
+github.com/klauspost/cpuid/v2 v2.1.1/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
+golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64 h1:UiNENfZ8gDvpiWw7IpOMQ27spWmThO1RwwdQVbJahJM=
+golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/map.go
+++ b/map.go
@@ -7,7 +7,7 @@ package hashmap
 import (
 	"unsafe"
 
-	"github.com/cespare/xxhash/v2"
+	"github.com/zeebo/xxh3"
 )
 
 const (
@@ -59,8 +59,8 @@ func (m *Map[K, V]) hash(key K) int {
 			len  int
 		}{unsafe.Pointer(&key), m.ksize}))
 	}
-	// Now for the actually hashing.
-	return int(xxhash.Sum64String(strKey) >> dibBitSize)
+	// Now for the actual hashing.
+	return int(xxh3.HashString(strKey) >> dibBitSize)
 }
 
 // Map is a hashmap. Like map[string]interface{}

--- a/map_test.go
+++ b/map_test.go
@@ -32,7 +32,7 @@ func add(x keyT, delta int) int {
 	return int(i + int64(delta))
 }
 
-///////////////////////////
+// /////////////////////////
 func random(N int, perm bool) []keyT {
 	nums := make([]keyT, N)
 	if perm {


### PR DESCRIPTION
## Proposed changes

- Add gitignore
- Lint README
- Update benchmark results in BENCH
- Use [xxh3](https://github.com/zeebo/xxh3), which I found to be significantly faster than xxhash in most cases as when compared to the standard library map. Benchmark comparison can be found below. Tested on AMD Ryzen 7 5800X, Manjaro Linux, Go 1.19. All test cases passed.

<table>
<tr>
<th>xxhash (old)</th>
<th>xxh3 (new)</th>
</tr>
<tr>
<td>

```shell
seed: 1661541371723767087

## STRING KEYS

-- tidwall --
set          100,000 ops     30ms      3,374,718/sec 
get          100,000 ops     19ms      5,195,199/sec 
reset        100,000 ops     16ms      6,210,687/sec 
scan              20 ops      9ms          2,106/sec 
delete       100,000 ops     17ms      6,034,829/sec 
memory     4,194,288 bytes                  41/entry 

-- stdlib --
set          100,000 ops     21ms      4,729,408/sec 
get          100,000 ops     11ms      9,132,903/sec 
reset        100,000 ops      8ms     13,307,516/sec 
scan              20 ops     25ms            791/sec 
delete       100,000 ops     10ms     10,505,883/sec 
memory     3,959,216 bytes                  39/entry


## INT KEYS

-- tidwall --
set          100,000 ops     15ms      6,758,532/sec 
get          100,000 ops      8ms     12,671,414/sec 
reset        100,000 ops      9ms     11,509,126/sec 
scan              20 ops      9ms          2,295/sec 
delete       100,000 ops      5ms     21,325,112/sec 
memory     3,143,368 bytes                  31/entry 

-- stdlib --
set          100,000 ops     12ms      8,096,538/sec 
get          100,000 ops      6ms     15,633,635/sec 
reset        100,000 ops      5ms     20,902,367/sec 
scan              20 ops     20ms            992/sec 
delete       100,000 ops      5ms     22,038,091/sec 
memory     2,765,832 bytes                  27/entry

seed: 1661541433491436408

## STRING KEYS

-- tidwall --
set        1,000,000 ops    286ms      3,493,008/sec 
get        1,000,000 ops    215ms      4,643,501/sec 
reset      1,000,000 ops    218ms      4,590,131/sec 
scan              20 ops    135ms            148/sec 
delete     1,000,000 ops    247ms      4,052,964/sec 
memory    67,108,848 bytes                  67/entry 

-- stdlib --
set        1,000,000 ops    328ms      3,052,252/sec 
get        1,000,000 ops    120ms      8,355,899/sec 
reset      1,000,000 ops    123ms      8,134,754/sec 
scan              20 ops    155ms            129/sec 
delete     1,000,000 ops    138ms      7,264,480/sec 
memory    57,931,472 bytes                  57/entry


## INT KEYS

-- tidwall --
set        1,000,000 ops    151ms      6,612,492/sec 
get        1,000,000 ops    113ms      8,845,072/sec 
reset      1,000,000 ops    110ms      9,114,482/sec 
scan              20 ops    138ms            145/sec 
delete     1,000,000 ops    109ms      9,197,197/sec 
memory    50,329,288 bytes                  50/entry 

-- stdlib --
set        1,000,000 ops    169ms      5,920,471/sec 
get        1,000,000 ops     75ms     13,293,602/sec 
reset      1,000,000 ops     60ms     16,693,933/sec 
scan              20 ops    155ms            129/sec 
delete     1,000,000 ops     69ms     14,499,619/sec 
memory    40,146,664 bytes                  40/entry

seed: 1661541461974249082

## STRING KEYS

-- tidwall --
set       10,000,000 ops   3165ms      3,159,250/sec 
get       10,000,000 ops   2589ms      3,862,272/sec 
reset     10,000,000 ops   2636ms      3,792,936/sec 
scan              20 ops   1031ms             19/sec 
delete    10,000,000 ops   2849ms      3,509,885/sec 
memory   536,870,904 bytes                  53/entry 

-- stdlib --
set       10,000,000 ops   3519ms      2,842,029/sec 
get       10,000,000 ops   1464ms      6,831,421/sec 
reset     10,000,000 ops   1437ms      6,960,506/sec 
scan              20 ops   1705ms             11/sec 
delete    10,000,000 ops   1557ms      6,422,395/sec 
memory   463,468,256 bytes                  46/entry 


## INT KEYS

-- tidwall --
set       10,000,000 ops   1691ms      5,915,152/sec 
get       10,000,000 ops   1326ms      7,544,039/sec 
reset     10,000,000 ops   1373ms      7,285,648/sec 
scan              20 ops   1073ms             18/sec 
delete    10,000,000 ops   1465ms      6,828,060/sec 
memory   402,650,824 bytes                  40/entry 

-- stdlib --
set       10,000,000 ops   1625ms      6,155,027/sec 
get       10,000,000 ops    745ms     13,430,294/sec 
reset     10,000,000 ops    828ms     12,074,512/sec 
scan              20 ops   1578ms             12/sec 
delete    10,000,000 ops    867ms     11,535,263/sec 
memory   321,976,040 bytes                  32/entry
```

</td>
<td>

```shell
seed: 1661541547938461762

## STRING KEYS

-- tidwall --
set          100,000 ops     24ms      4,149,762/sec 
get          100,000 ops     15ms      6,536,763/sec 
reset        100,000 ops     10ms      9,774,736/sec 
scan              20 ops     10ms          1,986/sec 
delete       100,000 ops      7ms     14,222,727/sec 
memory     4,194,288 bytes                  41/entry 

-- stdlib --
set          100,000 ops     17ms      5,818,370/sec 
get          100,000 ops      9ms     11,519,833/sec 
reset        100,000 ops      6ms     15,533,085/sec 
scan              20 ops     20ms            990/sec 
delete       100,000 ops     10ms     10,442,394/sec 
memory     3,961,296 bytes                  39/entry 


## INT KEYS

-- tidwall --
set          100,000 ops     12ms      8,150,474/sec 
get          100,000 ops      6ms     15,637,994/sec 
reset        100,000 ops      6ms     15,584,477/sec 
scan              20 ops      9ms          2,128/sec 
delete       100,000 ops      5ms     19,495,472/sec 
memory     3,143,352 bytes                  31/entry 

-- stdlib --
set          100,000 ops     10ms      9,584,498/sec 
get          100,000 ops      6ms     16,771,648/sec 
reset        100,000 ops      6ms     17,205,739/sec 
scan              20 ops     20ms          1,010/sec 
delete       100,000 ops      4ms     23,833,010/sec 
memory     2,766,120 bytes                  27/entry

seed: 1661541569345505845

## STRING KEYS

-- tidwall --
set        1,000,000 ops    221ms      4,517,183/sec 
get        1,000,000 ops    128ms      7,838,039/sec 
reset      1,000,000 ops    126ms      7,951,959/sec 
scan              20 ops    137ms            145/sec 
delete     1,000,000 ops    145ms      6,917,694/sec 
memory    67,108,848 bytes                  67/entry 

-- stdlib --
set        1,000,000 ops    309ms      3,232,441/sec 
get        1,000,000 ops    124ms      8,087,531/sec 
reset      1,000,000 ops    125ms      8,005,564/sec 
scan              20 ops    165ms            120/sec 
delete     1,000,000 ops    142ms      7,039,927/sec 
memory    57,931,568 bytes                  57/entry 


## INT KEYS

-- tidwall --
set        1,000,000 ops    124ms      8,067,036/sec 
get        1,000,000 ops     72ms     13,980,887/sec 
reset      1,000,000 ops     64ms     15,596,642/sec 
scan              20 ops    137ms            145/sec 
delete     1,000,000 ops     65ms     15,325,288/sec 
memory    50,329,272 bytes                  50/entry 

-- stdlib --
set        1,000,000 ops    126ms      7,921,841/sec 
get        1,000,000 ops     63ms     15,880,942/sec 
reset      1,000,000 ops     62ms     16,024,580/sec 
scan              20 ops    154ms            130/sec 
delete     1,000,000 ops     73ms     13,747,306/sec 
memory    40,146,856 bytes                  40/entry

seed: 1661541603926099681

## STRING KEYS

-- tidwall --
set       10,000,000 ops   2496ms      4,006,428/sec 
get       10,000,000 ops   1404ms      7,122,732/sec 
reset     10,000,000 ops   1460ms      6,848,696/sec 
scan              20 ops   1031ms             19/sec 
delete    10,000,000 ops   1710ms      5,848,611/sec 
memory   536,870,896 bytes                  53/entry 

-- stdlib --
set       10,000,000 ops   3678ms      2,719,207/sec 
get       10,000,000 ops   1476ms      6,775,262/sec 
reset     10,000,000 ops   1466ms      6,820,987/sec 
scan              20 ops   1770ms             11/sec 
delete    10,000,000 ops   1594ms      6,274,049/sec 
memory   463,468,240 bytes                  46/entry 


## INT KEYS

-- tidwall --
set       10,000,000 ops   1399ms      7,149,446/sec 
get       10,000,000 ops    720ms     13,888,579/sec 
reset     10,000,000 ops    782ms     12,793,742/sec 
scan              20 ops   1075ms             18/sec 
delete    10,000,000 ops    898ms     11,131,669/sec 
memory   402,650,808 bytes                  40/entry 

-- stdlib --
set       10,000,000 ops   1639ms      6,100,070/sec 
get       10,000,000 ops    770ms     12,988,335/sec 
reset     10,000,000 ops    852ms     11,743,657/sec 
scan              20 ops   1591ms             12/sec 
delete    10,000,000 ops    887ms     11,279,646/sec 
memory   321,976,040 bytes                  32/entry
```

</td>
</tr>
</table>